### PR TITLE
DAB-3: like py_example, but with sonar support

### DIFF
--- a/python3/py_example/.gitignore
+++ b/python3/py_example/.gitignore
@@ -1,5 +1,7 @@
-example.egg-info
-example/__pycache__
+py_example.egg-info
+py_example/__pycache__
 tests/__pycache__
 venv
 .idea
+.pytest_cache
+

--- a/python3/py_sonar/.gitignore
+++ b/python3/py_sonar/.gitignore
@@ -1,0 +1,8 @@
+.idea
+.pytest_cache
+py_sonar.egg-info
+py_sonar/__pycache__
+sonar.log.txt
+tests/__pycache__
+venv
+

--- a/python3/py_sonar/README.md
+++ b/python3/py_sonar/README.md
@@ -1,0 +1,105 @@
+## Python3 Example with Quality Analysis via SonarQube (aka sonar)
+
+This is a **bare-ish bones** sample python 3 project that comes with a sonar server.
+
+For truly bare-bones, looke at the `py_example` sibling project.
+
+### TLDR
+
+Do this in one window:
+```bash
+  ./start-sonar-server.sh; tail -f sonar.log.txt 
+```
+
+When it you see the log saying something like:
+```bash
+  sonarqube_1  | 1988.08.08 07:52:00 INFO  app[][o.s.a.SchedulerImpl] SonarQube is up
+```
+then you can ctrl-c it, or open a new window, and run these:
+```bash
+  # regular build and execute
+  #
+  ./clean.sh && ./build.sh && ./run.sh
+```
+
+```bash
+  # docker build and execute
+  #
+  ./clean.sh && ./docker-build.sh && ./docker-run.sh 
+```
+
+```bash
+  # regular build that you then analyze with sonar
+  #
+  ./clean.sh && ./build.sh && ./sonar-build.sh && ./sonar-run.sh
+```
+
+When that finishes, go here in a browser and go look at sonar:
+
+  http://localhost:9000/dashboard?id=py_sonar%3Aproject
+
+
+#### Where are my code police violations???
+
+When you do this for the first time, before putting _your_ code in this sample project, you won't see any code smell, even though you can see them in the flake8 and pylint output. That's because the default Quality Profile in sonar has those formatting problems turned off. If you want to start turning those on, you have to log in (admin/admin) and start messing around.
+
+This page will show you how to copy the default `C#` Quality Profile, and start customizing it. It's the same thing for Python:
+
+https://improveandrepeat.com/2017/12/customise-the-rules-in-sonarqube/
+
+You can then start turning rules on and off one at a time in that profile.
+
+Don't forget to set your new quality profile to the default profile.
+
+If you want the full picture of stuff to clean up, you can bulk activate all the rules in your new quality profile, and then start turning them off where they're being nit-picky. If you do this in this empty sample project, you'll see there are a lot of code smell violations, but turning off 2 or 3 formatting rules will take care of all of that.
+
+#### Changing the Rules and them Actually Showing Up???
+
+If you change the rules, you have to rerun the sonar-run.sh script.
+
+If you also changed your code, you should first run the build.sh script, followed by the sonar-build.sh script.
+
+### Done for the Day
+
+When you've fixed all the problems, you can stop your sonar server:
+```bash
+  ./stop-sonar-server.sh
+```
+
+If you were tailing the sonar log, you can ctrl-c it now.
+
+### Scripts
+
+clean.sh
+ - deletes old kruft.
+
+build.sh
+ - builds the code, runs the linter, and runs the tests.
+   you need to do this to get a sonar report.
+
+run.sh
+ - runs the code. 
+
+docker-build.sh
+ - builds, lints, and runs the test, this time inside a new docker container.
+
+docker-run.sh
+ - runs that docker container.
+
+sonar-build.sh
+ - builds the docker container that runs the sonar coverage report, using the current regular build state.
+
+sonar-run.sh
+ - runs the sonar coverage report in that container.
+
+start-sonar-server.sh
+ - starts the sonar server. 
+
+stop-sonar-server.sh
+  - stops the sonar server. run this when you're done for the day.
+
+### Why comments this time ???
+
+If you look at the `py_example` sibling project, we state specifically that we make no comments on purpose, because it's supposed to be so simple, you don't need them. But in this project, getting all the sonar stuff correct is subtle, and needs some `blah blah blah` here and there.
+
+Enjoy!

--- a/python3/py_sonar/build.sh
+++ b/python3/py_sonar/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# quietyly deactivate any previously active virtual environment.
+#
+2>&1 deactivate | grep -v 'deactivate: command not found'
+
+# nuke the old virtual environment, and make a new one.
+#
+rm -rf ./venv
+python3 -m venv ./venv
+
+# install our stuff in this new virtual environment.
+#
+. ./venv/bin/activate
+pip install -e .
+
+# flake8 gives some great python syntax police info.
+#
+flake8
+
+# so does pylint, which is what we send to sonar.
+#
+# the magic formatting mumbo-jumbo makes sonar happy.
+#
+pylint py_sonar -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee ./pylint.report
+pylint tests    -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee -a ./pylint.report
+
+# we also send sonar the test coverage report.
+#
+pytest --cov-report xml --cov=py_sonar tests/
+
+# we which need to make look like it was run in the container.
+#
+cat coverage.xml | sed "s|$(pwd)|/app|g" > coverage.sonar.xml
+

--- a/python3/py_sonar/clean.sh
+++ b/python3/py_sonar/clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+rm -rf ./venv ./py_sonar.egg-info
+
+rm -rf ./.pytest_cache ./tests/input_data .coverage ./coverage.xml ./coverage.sonar.xml ./sonar.log.txt
+
+rm -rf ./pylint.report
+
+find . -type f | grep pyc$ | xargs rm -f
+
+find . -type d | grep __pycache__ | xargs rm -rf
+
+docker rm $(docker ps -a | grep 'py_sonar:latest' | awk '{print $NF}')
+
+docker rmi $(docker images | tr -s ' ' | grep 'py_sonar latest' | cut -d' ' -f3)
+
+docker image prune --force
+

--- a/python3/py_sonar/docker-build.sh
+++ b/python3/py_sonar/docker-build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker build --no-cache --pull -t py_sonar -f docker/Dockerfile .
+
+docker run -t --rm py_sonar:latest flake8 .
+
+docker run -t --rm py_sonar:latest pylint py_sonar
+
+docker run -t --rm py_sonar:latest py.test
+

--- a/python3/py_sonar/docker-run.sh
+++ b/python3/py_sonar/docker-run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker run -t --rm py_sonar:latest python -m py_sonar.main --make continuously-driving --model container
+

--- a/python3/py_sonar/docker-sonar/Dockerfile
+++ b/python3/py_sonar/docker-sonar/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:8-jre-alpine
+
+ARG SONAR_SCANNER_VERSION
+ENV SONAR_SCANNER_VERSION=${SONAR_SCANNER_VERSION:-3.0.1.733}
+
+ADD "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip" /
+
+RUN unzip "sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip" \
+	&& rm /sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip 
+
+ENV PATH "/sonar-scanner-${SONAR_SCANNER_VERSION}/bin:${PATH}"
+
+ADD . /app
+
+WORKDIR /app
+
+ENTRYPOINT sonar-scanner
+

--- a/python3/py_sonar/docker-sonar/docker-compose.yaml
+++ b/python3/py_sonar/docker-sonar/docker-compose.yaml
@@ -1,0 +1,42 @@
+# This is the standard docker compose for running sonar.
+# There are many examples of this online, most of them exactly the same.
+
+version: "2"
+
+services:
+  sonarqube:
+    image: sonarqube
+    ports:
+      - "9000:9000"
+    networks:
+      - sonarnet
+    environment:
+      - sonar.jdbc.url=jdbc:postgresql://db:5432/sonar
+    volumes:
+      - sonarqube_conf:/opt/sonarqube/conf
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+
+  db:
+    image: postgres
+    networks:
+      - sonarnet
+    environment:
+      - POSTGRES_USER=sonar
+      - POSTGRES_PASSWORD=sonar
+    volumes:
+      - postgresql:/var/lib/postgresql
+      # This needs explicit mapping due to https://github.com/docker-library/postgres/blob/4e48e3228a30763913ece952c611e5e9b95c8759/Dockerfile.template#L52
+      - postgresql_data:/var/lib/postgresql/data
+
+networks:
+  sonarnet:
+    driver: bridge
+
+volumes:
+  sonarqube_conf:
+  sonarqube_data:
+  sonarqube_extensions:
+  postgresql:
+  postgresql_data:
+

--- a/python3/py_sonar/docker/Dockerfile
+++ b/python3/py_sonar/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7
+
+ADD . /py_sonar
+
+WORKDIR /py_sonar
+RUN pip install -e .
+

--- a/python3/py_sonar/my_project.sh
+++ b/python3/py_sonar/my_project.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Takes a copy of this repo, and let's you pick a new name for it.
+#
+# Changes all the files in place.
+#
+# If it screws up, or you don't like the name, start over from a fresh copy,
+#
+
+MY_PROJECT="$1"
+if [[ "x" == "x${MY_PROJECT}" ]]
+ then
+  echo "Pass me the new project name."
+  exit 1
+fi
+
+for file in $(grep -R 'py_sonar' . | sort | awk -F':' '{print $1}' | uniq);
+ do 
+  echo $file
+  cat $file | sed "s|py_sonar|${MY_PROJECT}|g" > ${file}.fixed
+done
+
+for file in $(find . -type f | grep fixed$)
+ do
+  NEW_NAME=${file}
+  OLD_NAME=$(echo $file | sed 's/.fixed$//g')
+  rm -f $OLD_NAME
+  mv $NEW_NAME $OLD_NAME
+done
+
+chmod +x *.sh
+
+mv py_sonar $MY_PROJECT
+

--- a/python3/py_sonar/py_sonar/car.py
+++ b/python3/py_sonar/py_sonar/car.py
@@ -1,0 +1,22 @@
+class Car():
+    """
+    A CRUD class for cars
+    """
+    def __init__(self, make: str, model: str):
+        self._make = make
+        self._model = model
+
+    def get_make(self) -> str:
+        return self._make
+
+    def get_model(self) -> str:
+        return self._model
+
+    def set_make(self, make):
+        self._make = make
+
+    def set_model(self, model):
+        self._model = model
+
+    def drive(self):
+        print(f"vroom vroom goes the {self._make} {self._model}")

--- a/python3/py_sonar/py_sonar/main.py
+++ b/python3/py_sonar/py_sonar/main.py
@@ -1,0 +1,33 @@
+import argparse
+
+from py_sonar import car
+
+
+def parseargs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--make", help="the make of the car")
+    parser.add_argument("--model", help="the model of the car")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+
+    args = parseargs()
+
+    if args.make:
+        make = args.make
+    else:
+        make = "tesla"
+
+    if args.model:
+        model = args.model
+    else:
+        model = "expensive"
+
+    new_car = car.Car(make, model)
+    new_car.drive()
+
+
+if __name__ == '__main__':
+    main()

--- a/python3/py_sonar/run.sh
+++ b/python3/py_sonar/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+. ./venv/bin/activate
+
+python -m py_sonar.main --make self-driving --model fantasy-land

--- a/python3/py_sonar/setup.cfg
+++ b/python3/py_sonar/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 120
+exclude =
+  venv/*,
+  .idea/*

--- a/python3/py_sonar/setup.py
+++ b/python3/py_sonar/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+requirements = [
+    "coverage",
+    "flake8",
+    "pylint",
+    "pytest",
+    "pytest-cov"
+]
+
+setup(name="py_sonar",
+      version="0.0.0",
+      author="Damon Berry",
+      packages=find_packages(),
+      install_requires=requirements)

--- a/python3/py_sonar/sonar-build.sh
+++ b/python3/py_sonar/sonar-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build --no-cache --pull -t py_sonar -f docker-sonar/Dockerfile .
+

--- a/python3/py_sonar/sonar-project.properties
+++ b/python3/py_sonar/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=py_sonar:project
+sonar.projectName=py_sonar
+sonar.projectVersion=0.0
+sonar.language=py
+sonar.sources=py_sonar
+sonar.tests=tests
+sonar.python.pylint.reportPath=pylint.report
+sonar.python.coverage.reportPath=coverage.sonar.xml
+sonar.sourceEncoding=UTF-8
+sonar.verbose=true

--- a/python3/py_sonar/sonar-run.sh
+++ b/python3/py_sonar/sonar-run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker run --network="host" -t --rm py_sonar:latest
+

--- a/python3/py_sonar/start-sonar-server.sh
+++ b/python3/py_sonar/start-sonar-server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+nohup 2>&1 docker-compose -f ./docker-sonar/docker-compose.yaml up > ./sonar.log.txt &
+

--- a/python3/py_sonar/stop-sonar-server.sh
+++ b/python3/py_sonar/stop-sonar-server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+nohup 2>&1 docker-compose -f ./docker-sonar/docker-compose.yaml down >> ./sonar.log.txt &
+

--- a/python3/py_sonar/tests/conftest.py
+++ b/python3/py_sonar/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from py_sonar.car import Car
+
+
+@pytest.fixture
+def tesla() -> Car:
+    return Car("tesla", "expensive")

--- a/python3/py_sonar/tests/test_broken.py
+++ b/python3/py_sonar/tests/test_broken.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.xfail(Strict="false")
+def test_busted(tesla):
+    assert tesla.get_model == "wrong"

--- a/python3/py_sonar/tests/test_tesla.py
+++ b/python3/py_sonar/tests/test_tesla.py
@@ -1,0 +1,9 @@
+from py_sonar.car import Car
+
+
+def test_tesla(tesla):
+
+    expected_results = Car("tesla", "expensive")
+
+    assert tesla.get_make() == expected_results.get_make()
+    assert tesla.get_model() == expected_results.get_model()


### PR DESCRIPTION
### What
This is just the sibling project [py_example](https://github.com/the-kakfa-dude/abides/tree/master/python3/py_example) fancied up to also have a sonar server.

### Why 
Being able to hit the ground running with a fresh python project that's got static analysis, test coverage reporting, a docker build that runs tests, etc... is awesome!

Setting this stuff up from scratch is a pain.

### Testing
First I cleaned up from last time, running the `./clean.sh` script in `py_sonar` from this branch.

Then I nuked my local docker stuff. 

DO NOT DO THIS
```bash
docker system prune -a -f
docker volume prune -f
```

Then I rsync-ed a copy of `py_sonar` over to another directory, and renamed the project like this:
```bash
./my_project.sh finale
```

Then I started the sonar server and waited for it to come up.
```bash
./start-sonar-server.sh; tail -f sonar.log.txt 
```

Then I ran it (3 different ways)
```bash
./clean.sh && ./build.sh && ./run.sh
./clean.sh && ./docker-build.sh && ./docker-run.sh 
./clean.sh && ./build.sh && ./sonar-build.sh && ./sonar-run.sh
```

Then I checked that the sonar report was correct, and shut it down.
```bash
./stop-sonar-server.sh 
```