### PR TITLE
DAB-9: update readme after actually having projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
+
+
 # abides
-There's stuff in here. Take a look...
+
+### What Lies Within
+
+In this repo, you will find starter projects in various languages.
+
+In each language, the "example" project is _extremely_ minimal, to the point where (almost) no comments are required.
+
+This example project is then extended to include other aspects you would want in a starter project, such as static analysis via SonarQube, a database, a REST server, functional tests to supplement the unit tests, and so on.
+
+### Work In Progress
+
+Right now, we are adding a (postgres) database to the `py_sonar` project, which is will be checked in next to it as `py_db_sonar`. As such, the support for functional tests we added in the `java_sonar` project will also be added to facilitate functional tests of our database code.
+
+We also have a typescript project being worked on in the background.
+
+### Future Work
+
+#### HTTP Server
+After adding a database to the python starter project, we will then add a REST server to that project.
+
+#### Code Generation
+In a subsequent project, we may choose to define that API Interface in Swagger, and appeal to some code-generation so that if that if someone changes the swagger without updating the underlying implementation, that implementation will generate (compile time) failures, for immediate alerting that something got out of sync. In the code generation project, we can also anticipate that certain implementation changes might also cause compile-time failures if the swagger was not also updated.
+
+Code generation like this is a great feature to have when you have developers sharing interface boundaries, where those developers may not be colocated, or for other situations which anticipate communication difficulties among developers.
+
+#### Sonar Plugin or Sonar Scanner
+When we added sonar support to the `java_sonar` starter project, because we wanted to demonstrate functional test support, the sonar-related changes in `build.gradle` got a bit messy. Later when we added sonar-scanner-via-docker to get sonar working with our python projects, we got some _very_ clean code. 
+
+A future project will be take to revisit `java_sonar`, and see if we can get cleaner functional test support by appealing the same sonar-scanner docker approachinstead of the gradle plugin for sonar.
+
+### Your Feature Requests
+The point of this project is to allow developers to hit the ground running in a new language, or for whom setting up a project with multifaceted support for things like static analysis, databases, http servers and the like would just be a distraction that slows you down from just writing the code.
+
+As a result, we want to hear from YOU about what is good in here, what is bad in here, and what you want to see changed or added next. You can make your desires known by sending mail to: the dude AT kakfa dot com (no spaces)
+
+Cheers and Good Luck!
+


### PR DESCRIPTION
### Jira
[DAB-9](http://localhost:8080/browse/DAB-9)

### What
Better Readme, now that we actually have a project or two.

### Why
So people can better understand why they should give a hoot about the `abides` repo.

### Testing
I reviewed the new document in a spell checker, and checked the markup layout by viewing the file as md in this PR.