### PR TITLE
DAB-10: better unit tests in py_sonar

### DIFF
--- a/python3/py_sonar/build.sh
+++ b/python3/py_sonar/build.sh
@@ -22,12 +22,11 @@ flake8
 #
 # the magic formatting mumbo-jumbo makes sonar happy.
 #
-pylint py_sonar -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee ./pylint.report
-pylint tests    -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee -a ./pylint.report
+pylint py_sonar tests -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" | tee ./pylint.report
 
 # we also send sonar the test coverage report.
 #
-pytest --cov-report xml --cov=py_sonar tests/
+pytest --cov-report xml --cov=py_sonar tests
 
 # we which need to make look like it was run in the container.
 #

--- a/python3/py_sonar/docker-build.sh
+++ b/python3/py_sonar/docker-build.sh
@@ -4,7 +4,7 @@ docker build --no-cache --pull -t py_sonar -f docker/Dockerfile .
 
 docker run -t --rm py_sonar:latest flake8 .
 
-docker run -t --rm py_sonar:latest pylint py_sonar
+docker run -t --rm py_sonar:latest pylint py_sonar tests
 
-docker run -t --rm py_sonar:latest py.test
+docker run -t --rm py_sonar:latest py.test tests
 

--- a/python3/py_sonar/py_sonar/car.py
+++ b/python3/py_sonar/py_sonar/car.py
@@ -1,22 +1,23 @@
 class Car():
     """
-    A CRUD class for cars
+    A class for cars
     """
     def __init__(self, make: str, model: str):
-        self._make = make
-        self._model = model
+        self.make = make
+        self.model = model
 
     def get_make(self) -> str:
-        return self._make
+        return self.make
 
     def get_model(self) -> str:
-        return self._model
+        return self.model
 
     def set_make(self, make):
-        self._make = make
+        self.make = make
 
     def set_model(self, model):
-        self._model = model
+        self.model = model
 
     def drive(self):
-        print(f"vroom vroom goes the {self._make} {self._model}")
+        message = f"vroom vroom goes the {self.make} {self.model}"
+        print(message)

--- a/python3/py_sonar/py_sonar/main.py
+++ b/python3/py_sonar/py_sonar/main.py
@@ -1,32 +1,64 @@
 import argparse
 
-from py_sonar import car
+from py_sonar.car import Car
 
 
 def parseargs() -> argparse.Namespace:
+    """
+    Sets up our command line interface.
+
+    :return: The standard args parser.
+    """
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--make", help="the make of the car")
-    parser.add_argument("--model", help="the model of the car")
-    args = parser.parse_args()
-    return args
+    parser.add_argument("--make",
+                        dest='make',
+                        type=str,
+                        default=None,
+                        help="the make of the car")
+    parser.add_argument("--model",
+                        dest='model',
+                        type=str,
+                        default=None,
+                        help="the model of the car")
+
+    return parser.parse_args()
 
 
-def main():
+def args_to_car(car_args) -> Car:
+    """
+    Takes the presented car args and returns a car object that represents it.
 
-    args = parseargs()
+    :param car_args: Our argsparse object, or a Car (which has the same signature).
 
-    if args.make:
-        make = args.make
+    :return: A car matching the presented args.
+             If you actually pass me a Car instace, we return a new one.
+    """
+
+    if car_args.make:
+        make = car_args.make
     else:
         make = "tesla"
 
-    if args.model:
-        model = args.model
+    if car_args.model:
+        model = car_args.model
     else:
         model = "expensive"
 
-    new_car = car.Car(make, model)
-    new_car.drive()
+    car = Car(make, model)
+    return car
+
+
+def main():
+    """
+    Parses the command-line arguments, turns them into a car, and takes it for a drive.
+
+    :return: This method does not return a value.
+    """
+
+    args = parseargs()
+    car = args_to_car(args)
+    car.drive()
 
 
 if __name__ == '__main__':

--- a/python3/py_sonar/tests/conftest.py
+++ b/python3/py_sonar/tests/conftest.py
@@ -5,3 +5,8 @@ from py_sonar.car import Car
 @pytest.fixture
 def tesla() -> Car:
     return Car("tesla", "expensive")
+
+
+@pytest.fixture
+def klunker() -> Car:
+    return Car("klunker", "cheap")

--- a/python3/py_sonar/tests/test_args.py
+++ b/python3/py_sonar/tests/test_args.py
@@ -1,0 +1,36 @@
+from py_sonar.car import Car
+from py_sonar.main import args_to_car
+
+
+def test_from_args():
+    """
+    Validates that if you start with a car-like object,
+    (meaning something that has a dot-make and a dot-model),
+    you get back a car with the same make and model.
+
+    :return: there is no return from this method.
+    """
+
+    expected = Car("something", "random")
+    actual = args_to_car(expected)
+
+    assert isinstance(actual, Car)
+    assert actual.get_make() == expected.get_make()
+    assert actual.get_model() == expected.get_model()
+
+
+def test_default_from_args(tesla):
+    """
+    Validates that if the make and model args are None, that we get back
+    the default car, which has the same make and model as the tesla test fixture.
+
+    :param tesla: the tesla text fixture.
+    :return: there is no return from this method.
+    """
+
+    empty_car = Car(None, None)
+    actual = args_to_car(empty_car)
+
+    assert isinstance(actual, Car)
+    assert actual.get_make() == tesla.get_make()
+    assert actual.get_model() == tesla.get_model()

--- a/python3/py_sonar/tests/test_broken.py
+++ b/python3/py_sonar/tests/test_broken.py
@@ -3,4 +3,12 @@ import pytest
 
 @pytest.mark.xfail(Strict="false")
 def test_busted(tesla):
-    assert tesla.get_model == "wrong"
+    """
+    This is just to illustrate how you mark a test as flaky,
+    and tell pytest that that's okay.
+
+    :param tesla: the tesla test fixture.
+
+    :return: this function does not return a value.
+    """
+    assert tesla.get_model() == "wrong"

--- a/python3/py_sonar/tests/test_car.py
+++ b/python3/py_sonar/tests/test_car.py
@@ -1,0 +1,52 @@
+from py_sonar.car import Car
+
+
+def test_klunker(klunker):
+    """
+    Validates constructing a Car via the klunker test fixture.
+
+    :param klunker: the test fixture
+    :return: there is no return from this function.
+    """
+
+    actual = Car(klunker.get_make(), klunker.get_model())
+
+    assert actual.get_make() == klunker.get_make()
+    assert actual.get_model() == klunker.get_model()
+
+
+def test_nones():
+    """
+    Validates you can construct a car without specifying
+    real values for make and model.
+
+    We don't use the tesla here, because that make and model is the default.
+
+    :param klunker: the test fixture
+    :return: there is no return from this function.
+    """
+
+    actual = Car(None, None)
+
+    assert actual.get_make() is None
+    assert actual.get_model() is None
+
+
+def test_setters():
+    """
+    Validates you can construct can update the make and model
+
+    :param klunker: the test fixture
+    :return: there is no return from this function.
+    """
+
+    actual = Car('ford', 'truck')
+
+    assert actual.get_make() == 'ford'
+    assert actual.get_model() == 'truck'
+
+    actual.set_make('not_ford')
+    assert actual.get_make() == 'not_ford'
+
+    actual.set_model('not_truck')
+    assert actual.get_model() == 'not_truck'

--- a/python3/py_sonar/tests/test_main.py
+++ b/python3/py_sonar/tests/test_main.py
@@ -1,0 +1,25 @@
+import argparse
+
+from io import StringIO
+from unittest import mock, TestCase
+
+from py_sonar.main import main
+
+
+@mock.patch('sys.stdout', new_callable=StringIO)
+@mock.patch('argparse.ArgumentParser.parse_args',
+            return_value=argparse.Namespace(make='foo', model='bar'))
+class TestMainClass(TestCase):
+    """
+    If you want to patch more than one thing in a test,
+    like standard out and the standard args parser,
+    making a like this class is the best way to do it.
+    """
+
+    def test_main(self, _, mock_stdout):
+
+        main()
+
+        self.assertEqual(mock_stdout.getvalue(),
+                         'vroom vroom goes the foo bar\n',  # don't forget the trailing newline
+                         'we did not get a vroom vroom for make foo and model bar')


### PR DESCRIPTION
### Jira
[DAB-10](http://localhost:8080/browse/DAB-10)

### What
When we were working on [DAB-7](http://localhost:8080/browse/DAB-7) we ended up with much better unit tests, and better code (and build) as a result.

This is the backport of those unit tests from the WIP `py_db_sonar` to the `py_sonar` project on which it was based.

### Why
Sweet tests, and test based refactoring, needs to be shared.

### Test
These changes pass local tests, and have a much cleaner sonar report.