### PR TITLE
DAB-16: add my_project.sh script to java_sonar starter project

### DIFF
--- a/java8/java_sonar/README.md
+++ b/java8/java_sonar/README.md
@@ -1,7 +1,19 @@
-### Starting the sonar server
+# Java 8 Example With Gradle Build System and Quality Analysis
+
+This is a sample project that uses the Gradle build system,
+and uses a SonarQube server for Quality Analysis.
+
+This project was written for Java 8.
+
+The tests are all unit tests, and in the standard location.
+
+If you don't need want functional tests and quality analysis,
+see our sibling project `java_example`. 
+
+### Start The Sonar Server
 
 ```bash
-gradle composeUp
+./gradlew composeUp
 ```
 
 Then go to:
@@ -10,38 +22,102 @@ Then go to:
 
 and wait until it's done "starting up".
 
-### Building The Code and Running The Tests
+
+### Clean It
 
 ```bash
-gradle clean build 
+./gradlew clean
 ```
 
-This ^^^ will run both the unit and functional tests.
-
-### Getting that Data Into SonarQube
+### Build It And Run The Tests
 
 ```bash
-gradle clean build sonar
+./gradlew build 
 ```
 
-### Running the App
+### Zip It Into A Jar File 
 
 ```bash
-gradle run
+./gradlew jar
 ```
 
-### Cleaning up
+### Run It
 
 ```bash
-gradle clean
-rm -rf .gradle
+./gradlew run
 ```
 
-### Done for the Day
+### Pushing Latest Build To Sonar
+
+```bash
+./gradlew sonar
+```
+
+## Development Loop
+
+If you want to rebuild and rerun everything from scratch, do this:
+
+```bash
+rm -rf .gradle ./build ./bin ; ./gradlew clean build test funcTest jar run sonar
+```
+
+### But I Don't Need To Type That Much!
+When your gradle tasks are default (like in this project),
+or properly modified or extended (like hopefully our other projects)
+you don't really need to specify each of the tasks above, as some
+will run others.
+
+For instance, a build with do a test, a run will do build but not a jar,
+and so on. The result is you end up getting some taks for free.
+
+However, as soon as you start adding new tasks, or otherwise changing the
+`build.gradle` file, it's pretty easy to screw up your task dependency graph,
+and get weird behavior when running gradle tasks.
+
+By specifying each of the required tasks that lead up to a run, in order,
+you are giving yourself a chance to move forward _now_, despite having
+screwed up the task hierarchy.
+
+(todo: fix the graph _later_)
+
+;o)
+
+
+## Done for the Day
 
 You can stop your sonar server like this:
 ```bash
-gradle composeDown
+./gradlew composeDown
 ```
 
-Enjoy!
+Then you can remove the local build artifacts like this:
+```bash
+rm -rf .gradle ./build ./bin
+
+./gradlew clean
+```
+
+## Rename and Repackage This Thing
+
+If you want to take this starter project and turn it into your own project,
+you can run the `my_project.sh` script. Other starter projects in this repo
+will also have one of these.
+
+For the `my_project.sh` in _this_ project, you pass it a new project name and
+a new package name. The current project namem is `java_sonar` and the current
+java package is `com.kakfa`
+
+For example, if you wanted to call this project `bunnies` and you were working for
+the platform team at a company called `example.com`, you would invoke the script
+like this:
+
+```bash
+./my_project.sh bunnies com.example.platform
+```
+
+That will change all the names in the source files in this project,
+and move the fixed up code to the new package location.
+
+You can test the result by running a `./gradlew run` and seeing if it spits out `Hello world.`
+
+## Enjoy!

--- a/java8/java_sonar/build.gradle
+++ b/java8/java_sonar/build.gradle
@@ -21,7 +21,7 @@ dockerCompose {
 
 application {
     // Define the main class for the application
-    mainClassName = 'java_sonar.App'
+    mainClassName = 'com.kakfa.App'
 }
 
 sourceSets {

--- a/java8/java_sonar/my_project.sh
+++ b/java8/java_sonar/my_project.sh
@@ -11,7 +11,7 @@
 # so if running this script crashes,
 # you will want to checkout a fresh copy.
 #
-CURRENT_PROJECT="java_example"
+CURRENT_PROJECT="java_sonar"
 CURRENT_PACKAGE="com.kakfa"
 
 # parse command line args
@@ -85,20 +85,6 @@ function change_names() {
   done
 }
 
-NEW_PROJECT="$1"
-if [[ "x" == "x${NEW_PROJECT}" ]]
- then
-  echo "Pass me the new project name. The current package is called: $CURRENT_PROJECT"
-  exit 1
-fi
-
-NEW_PACKAGE="$2"
-if [[ "x" == "x${NEW_PACKAGE}" ]]
- then
-  echo "Pass me the new package name. The current package is called: $CURRENT_PACKAGE"
-  exit 1
-fi
-
 
 # replace the project name
 #
@@ -121,13 +107,15 @@ NEW_DIR=$(to_directory_regex "$NEW_PACKAGE")
 
 mkdir -p ./src/main/java/${NEW_DIR}
 mkdir -p ./src/test/java/${NEW_DIR}
+mkdir -p ./src/funcTest/java/${NEW_DIR}
 
-# be naive and assume all we need to move is the contents
-# of the final package.
+# be naive and assume all we need to move is the contents of the final package.
+#
 rsync -avPr ./src/main/java/${CURRENT_DIR}/* ./src/main/java/${NEW_DIR}/
 rsync -avPr ./src/test/java/${CURRENT_DIR}/* ./src/test/java/${NEW_DIR}/
+rsync -avPr ./src/funcTest/java/${CURRENT_DIR}/* ./src/funcTest/java/${NEW_DIR}/
 
-rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR}
+rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR} ./src/funcTest/java/${CURRENT_DIR}
 
 # since we couldn't sed the files in place (thanks apple),
 # we have to reset the executable bit on our shell scripts

--- a/java8/java_sonar/src/funcTest/java/com/kakfa/AppFuncTest.java
+++ b/java8/java_sonar/src/funcTest/java/com/kakfa/AppFuncTest.java
@@ -1,4 +1,4 @@
-package java_sonar;
+package com.kakfa;
 
 import org.junit.After;
 import org.junit.Test;
@@ -30,7 +30,7 @@ public class AppFuncTest {
     public void testAsProcess() {
         
         File directory = new File(WORKING_DIR);
-        String[] commands = { "java", "-cp", "./build/libs/java_sonar.jar", "java_sonar.App" };
+        String[] commands = { "java", "-cp", "./build/libs/java_sonar.jar", "com.kakfa.App" };
         String[] results = FuncTestUtils.getInstance().executeCommands(commands, directory, TIMEOUT_SECONDS);
         
         assertEquals("We didn't get two strings back", 2, results.length);

--- a/java8/java_sonar/src/funcTest/java/com/kakfa/FuncTestUtils.java
+++ b/java8/java_sonar/src/funcTest/java/com/kakfa/FuncTestUtils.java
@@ -1,4 +1,4 @@
-package java_sonar;
+package com.kakfa;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/java8/java_sonar/src/main/java/com/kakfa/App.java
+++ b/java8/java_sonar/src/main/java/com/kakfa/App.java
@@ -1,4 +1,4 @@
-package java_sonar;
+package com.kakfa;
 
 import java.util.logging.Level; 
 import java.util.logging.Logger; 

--- a/java8/java_sonar/src/test/java/com/kakfa/AppTest.java
+++ b/java8/java_sonar/src/test/java/com/kakfa/AppTest.java
@@ -1,4 +1,4 @@
-package java_sonar;
+package com.kakfa;
 
 import org.junit.Test;
 import static org.junit.Assert.*;


### PR DESCRIPTION
### Jira
[DAB-16](http://localhost:8080/browse/DAB-16)

### What
Standardize the `java_sonar` project a bit, relative to the other projects, by adding the script that lets you re-skin it, and repackage it to use the `com.kakfa` instead of the name of the project.

### Why
Copying some magic project and then having to search and replace over all of the files by hand sux.

### Test
All unit and functional tests pass.

A manual test of the re-skinning scrip