### PR TITLE
DAB-18: call it test_db, run it on an alternate port

### DIFF
--- a/python3/py_db_sonar/docker/postgres/docker-compose.yaml
+++ b/python3/py_db_sonar/docker/postgres/docker-compose.yaml
@@ -3,7 +3,7 @@
 version: "2"
 
 services:
-  db:
+  test_db:
     image: postgres:11  # we can't use latest becuase brew lags behind, and we need psql
     networks:
       - py_db_sonar_net
@@ -13,7 +13,7 @@ services:
       - py_db_sonar:/var/lib/postgresql
       - py_db_sonar_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
 
 networks:
   py_db_sonar_net:

--- a/python3/py_db_sonar/psql-sudo.sh
+++ b/python3/py_db_sonar/psql-sudo.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=py_db_sonar_sudo psql -h localhost -U postgres "$@"
+PGPORT=5433 PGPASSWORD=py_db_sonar_sudo psql -h localhost -U postgres "$@"
 

--- a/python3/py_db_sonar/psql-user.sh
+++ b/python3/py_db_sonar/psql-user.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=py_db_sonar_pass psql -U py_db_sonar_user -h localhost -d py_db_sonar "$@"
+PGPORT=5433 PGPASSWORD=py_db_sonar_pass psql -U py_db_sonar_user -h localhost -d py_db_sonar "$@"
 

--- a/python3/py_db_sonar/py_db_sonar/__init__.py
+++ b/python3/py_db_sonar/py_db_sonar/__init__.py
@@ -4,7 +4,7 @@ DRIVER = 'postgresql+psycopg2'
 USER = 'py_db_sonar_user'
 PASSWORD = 'py_db_sonar_pass'
 SERVER = 'localhost'
-PORT = 5432
+PORT = 5433
 DATABASE = 'py_db_sonar'
 POSTGRES_URL = f'{DRIVER}://{USER}:{PASSWORD}@{SERVER}:{PORT}/{DATABASE}'
 

--- a/python3/py_db_sonar/reset-db.sh
+++ b/python3/py_db_sonar/reset-db.sh
@@ -10,8 +10,8 @@
 #
 # To force it to go down, run these:
 #
-#    docker stop postgres_db_1
-#    docker rm -v postgres_db_1
+#    docker stop postgres_test_db_1
+#    docker rm -v postgres_test_db_1
 #
 # and then run this script again.
 #


### PR DESCRIPTION


### What
We renamed the functional test database in `py_db_sonar` to "test_db" in its docker compose, and run it on a non-standard port.

### Why
We need to use a single `docker-compose.yaml` in the new `java_db_sonar`, which already contains a postgres database that sonar is expecting on the standard port.

### Testing
We went through the readme top to bottom and ran all the commands.