### PR TITLE
Release 3.2.1 (2019-10-23)

### DIFF
--- a/java8/java_example/my_project.sh
+++ b/java8/java_example/my_project.sh
@@ -85,49 +85,60 @@ function change_names() {
   done
 }
 
-NEW_PROJECT="$1"
-if [[ "x" == "x${NEW_PROJECT}" ]]
+if [[ "$CURRENT_PROJECT" != "$NEW_PROJECT" ]]
  then
-  echo "Pass me the new project name. The current package is called: $CURRENT_PROJECT"
-  exit 1
+
+  # replace the project name
+  #
+  change_names "$CURRENT_PROJECT" "$NEW_PROJECT"
 fi
 
-NEW_PACKAGE="$2"
-if [[ "x" == "x${NEW_PACKAGE}" ]]
+if [[ "$CURRENT_PACKAGE" != "$NEW_PACKAGE" ]]
  then
-  echo "Pass me the new package name. The current package is called: $CURRENT_PACKAGE"
-  exit 1
+  # changing the package names requires escaping the dot characters.
+  #
+  CP_REGEX=$(to_package_regex "$CURRENT_PACKAGE")
+  NP_REGEX=$(to_package_regex "$NEW_PACKAGE")
+  change_names "$CP_REGEX" "$NP_REGEX"
+
+  # move the code fromm the old package to the new one.
+  #
+  # the easiest way to do this is to just create the two
+  # new directories (one in main, one in test) and rsync
+  # the code from the old location to the new location.
+  #
+  CURRENT_DIR=$(to_directory_regex "$CURRENT_PACKAGE")
+  NEW_DIR=$(to_directory_regex "$NEW_PACKAGE")
+
+  mkdir -p ./src/main/java/${NEW_DIR}
+  mkdir -p ./src/test/java/${NEW_DIR}
+
+  # be naive and assume all we need to move is the contents
+  # of the final package.
+  rsync -avPr ./src/main/java/${CURRENT_DIR}/* ./src/main/java/${NEW_DIR}/
+  rsync -avPr ./src/test/java/${CURRENT_DIR}/* ./src/test/java/${NEW_DIR}/
+
+  # if the target dir is different than the source dir,
+  # and not a sub-dir, then we should remove the source dir.
+  #
+  # if it is a sub-dir, we need to remove the files from the parent,
+  # but leave the directories alone, since one of those directories
+  # contains the newly packaged code.
+  #
+  if [[ $NEW_DIR != $CURRENT_DIR ]]
+   then
+    if [[ $NEW_DIR == $CURRENT_DIR* ]]
+     then
+      # it's a subdir. remove the files from the parent, but not the directories
+      #
+      rm -f ./src/main/java/${CURRENT_DIR}/* ./src/test/java/${CURRENT_DIR}/*
+     else
+      # it's just a regular old dir. remove it.
+      #
+      rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR}
+     fi
+   fi
 fi
-
-
-# replace the project name
-#
-change_names "$CURRENT_PROJECT" "$NEW_PROJECT"
-
-# changing the package names requires escaping the dot characters.
-#
-CP_REGEX=$(to_package_regex "$CURRENT_PACKAGE")
-NP_REGEX=$(to_package_regex "$NEW_PACKAGE")
-change_names "$CP_REGEX" "$NP_REGEX"
-
-# move the code fromm the old package to the new one.
-#
-# the easiest way to do this is to just create the two
-# new directories (one in main, one in test) and rsync
-# the code from the old location to the new location.
-#
-CURRENT_DIR=$(to_directory_regex "$CURRENT_PACKAGE")
-NEW_DIR=$(to_directory_regex "$NEW_PACKAGE")
-
-mkdir -p ./src/main/java/${NEW_DIR}
-mkdir -p ./src/test/java/${NEW_DIR}
-
-# be naive and assume all we need to move is the contents
-# of the final package.
-rsync -avPr ./src/main/java/${CURRENT_DIR}/* ./src/main/java/${NEW_DIR}/
-rsync -avPr ./src/test/java/${CURRENT_DIR}/* ./src/test/java/${NEW_DIR}/
-
-rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR}
 
 # since we couldn't sed the files in place (thanks apple),
 # we have to reset the executable bit on our shell scripts

--- a/java8/java_sonar/my_project.sh
+++ b/java8/java_sonar/my_project.sh
@@ -86,36 +86,62 @@ function change_names() {
 }
 
 
-# replace the project name
-#
-change_names "$CURRENT_PROJECT" "$NEW_PROJECT"
+if [[ "$CURRENT_PROJECT" != "$NEW_PROJECT" ]]
+ then
 
-# changing the package names requires escaping the dot characters.
-#
-CP_REGEX=$(to_package_regex "$CURRENT_PACKAGE")
-NP_REGEX=$(to_package_regex "$NEW_PACKAGE")
-change_names "$CP_REGEX" "$NP_REGEX"
+  # replace the project name
+  #
+  change_names "$CURRENT_PROJECT" "$NEW_PROJECT"
+fi
 
-# move the code fromm the old package to the new one.
-#
-# the easiest way to do this is to just create the two
-# new directories (one in main, one in test) and rsync
-# the code from the old location to the new location.
-#
-CURRENT_DIR=$(to_directory_regex "$CURRENT_PACKAGE")
-NEW_DIR=$(to_directory_regex "$NEW_PACKAGE")
+if [[ "$CURRENT_PACKAGE" != "$NEW_PACKAGE" ]]
+ then
+  # changing the package names requires escaping the dot characters.
+  #
+  CP_REGEX=$(to_package_regex "$CURRENT_PACKAGE")
+  NP_REGEX=$(to_package_regex "$NEW_PACKAGE")
+  change_names "$CP_REGEX" "$NP_REGEX"
 
-mkdir -p ./src/main/java/${NEW_DIR}
-mkdir -p ./src/test/java/${NEW_DIR}
-mkdir -p ./src/funcTest/java/${NEW_DIR}
+  # move the code fromm the old package to the new one.
+  #
+  # the easiest way to do this is to just create the two
+  # new directories (one in main, one in test) and rsync
+  # the code from the old location to the new location.
+  #
+  CURRENT_DIR=$(to_directory_regex "$CURRENT_PACKAGE")
+  NEW_DIR=$(to_directory_regex "$NEW_PACKAGE")
 
-# be naive and assume all we need to move is the contents of the final package.
-#
-rsync -avPr ./src/main/java/${CURRENT_DIR}/* ./src/main/java/${NEW_DIR}/
-rsync -avPr ./src/test/java/${CURRENT_DIR}/* ./src/test/java/${NEW_DIR}/
-rsync -avPr ./src/funcTest/java/${CURRENT_DIR}/* ./src/funcTest/java/${NEW_DIR}/
+  mkdir -p ./src/main/java/${NEW_DIR}
+  mkdir -p ./src/test/java/${NEW_DIR}
+  mkdir -p ./src/funcTest/java/${NEW_DIR}
 
-rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR} ./src/funcTest/java/${CURRENT_DIR}
+  # be naive and assume all we need to move is the contents
+  # of the final package.
+  rsync -avPr ./src/main/java/${CURRENT_DIR}/* ./src/main/java/${NEW_DIR}/
+  rsync -avPr ./src/test/java/${CURRENT_DIR}/* ./src/test/java/${NEW_DIR}/
+  rsync -avPr ./src/funcTest/java/${CURRENT_DIR}/* ./src/funcTest/java/${NEW_DIR}/
+
+  # if the target dir is different than the source dir,
+  # and not a sub-dir, then we should remove the source dir.
+  #
+  # if it is a sub-dir, we need to remove the files from the parent,
+  # but leave the directories alone, since one of those directories
+  # contains the newly packaged code.
+  #
+  if [[ $NEW_DIR != $CURRENT_DIR ]]
+   then
+    if [[ $NEW_DIR == $CURRENT_DIR* ]]
+     then
+      # it's a subdir. remove the files from the parent, but not the directories
+      #
+      rm -f ./src/main/java/${CURRENT_DIR}/* ./src/test/java/${CURRENT_DIR}/* ./src/funcTest/java/${CURRENT_DIR}/*
+     else
+      # it's just a regular old dir. remove it.
+      #
+      rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR} ./src/funcTest/java/${CURRENT_DIR}
+     fi
+   fi
+fi
 
 # since we couldn't sed the files in place (thanks apple),
 # we have to reset the executable bit on our shell scripts

--- a/python3/py_db_sonar/docker/postgres/docker-compose.yaml
+++ b/python3/py_db_sonar/docker/postgres/docker-compose.yaml
@@ -3,7 +3,7 @@
 version: "2"
 
 services:
-  db:
+  test_db:
     image: postgres:11  # we can't use latest becuase brew lags behind, and we need psql
     networks:
       - py_db_sonar_net
@@ -13,7 +13,7 @@ services:
       - py_db_sonar:/var/lib/postgresql
       - py_db_sonar_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
 
 networks:
   py_db_sonar_net:

--- a/python3/py_db_sonar/psql-sudo.sh
+++ b/python3/py_db_sonar/psql-sudo.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=py_db_sonar_sudo psql -h localhost -U postgres "$@"
+PGPORT=5433 PGPASSWORD=py_db_sonar_sudo psql -h localhost -U postgres "$@"
 

--- a/python3/py_db_sonar/psql-user.sh
+++ b/python3/py_db_sonar/psql-user.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-PGPASSWORD=py_db_sonar_pass psql -U py_db_sonar_user -h localhost -d py_db_sonar "$@"
+PGPORT=5433 PGPASSWORD=py_db_sonar_pass psql -U py_db_sonar_user -h localhost -d py_db_sonar "$@"
 

--- a/python3/py_db_sonar/py_db_sonar/__init__.py
+++ b/python3/py_db_sonar/py_db_sonar/__init__.py
@@ -4,7 +4,7 @@ DRIVER = 'postgresql+psycopg2'
 USER = 'py_db_sonar_user'
 PASSWORD = 'py_db_sonar_pass'
 SERVER = 'localhost'
-PORT = 5432
+PORT = 5433
 DATABASE = 'py_db_sonar'
 POSTGRES_URL = f'{DRIVER}://{USER}:{PASSWORD}@{SERVER}:{PORT}/{DATABASE}'
 

--- a/python3/py_db_sonar/reset-db.sh
+++ b/python3/py_db_sonar/reset-db.sh
@@ -10,8 +10,8 @@
 #
 # To force it to go down, run these:
 #
-#    docker stop postgres_db_1
-#    docker rm -v postgres_db_1
+#    docker stop postgres_test_db_1
+#    docker rm -v postgres_test_db_1
 #
 # and then run this script again.
 #


### PR DESCRIPTION
In this PR we had to create a release branch dude to conflicts trying to merge `develop` directly into `master`.

The tickets contained in this release are:
[DAB-14](http://localhost:8080/browse/DAB-14)
[DAB-16](http://localhost:8080/browse/DAB-16)
[DAB-18](http://localhost:8080/browse/DAB-18)
[DAB-19](http://localhost:8080/browse/DAB-19)

These are basically the `my_project.sh` script fixes/additions, and running the test database in `py_db_sonar` on an alternate port.

After merging this into master, this will be tagged as Version 3.2.1