### PR TITLE
DAB-21: fix my_project.sh issues

### DIFF
--- a/java8/java_db_sonar/my_project.sh
+++ b/java8/java_db_sonar/my_project.sh
@@ -134,19 +134,19 @@ if [[ "$CURRENT_PACKAGE" != "$NEW_PACKAGE" ]]
      then
       # it's a subdir. remove the files from the parent, but not the directories
       #
-      rm -f ./src/main/java/${CURRENT_DIR}/* ./src/test/java/${CURRENT_DIR}/*
+      rm -f ./src/main/java/${CURRENT_DIR}/* ./src/test/java/${CURRENT_DIR}/* ./src/funcTest/java/${CURRENT_DIR}/*
      else
       # it's just a regular old dir. remove it.
       #
-      rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR}
+      rm -rf ./src/main/java/${CURRENT_DIR} ./src/test/java/${CURRENT_DIR} ./src/funcTest/java/${CURRENT_DIR}
      fi
    fi
 fi
 
-# since we couldn't sed the files in place (thanks apple),
-# we have to reset the executable bit on our shell scripts
+# find all the scripts that lost their executable bit,
+# and set it again.
 #
-find . -type f -name *.sh | xargs chmod +x
+find . -type f | grep sh$ | xargs chmod +x
 
 # the local .gradle folder will contain aritfacts with the old name.
 # clean house.

--- a/java8/java_example/my_project.sh
+++ b/java8/java_example/my_project.sh
@@ -140,10 +140,10 @@ if [[ "$CURRENT_PACKAGE" != "$NEW_PACKAGE" ]]
    fi
 fi
 
-# since we couldn't sed the files in place (thanks apple),
-# we have to reset the executable bit on our shell scripts
+# find all the scripts that lost their executable bit,
+# and set it again.
 #
-find . -type f -name *.sh | xargs chmod +x
+find . -type f | grep sh$ | xargs chmod +x
 
 # the local .gradle folder will contain aritfacts with the old name.
 # clean house.

--- a/java8/java_sonar/my_project.sh
+++ b/java8/java_sonar/my_project.sh
@@ -141,10 +141,10 @@ if [[ "$CURRENT_PACKAGE" != "$NEW_PACKAGE" ]]
    fi
 fi
 
-# since we couldn't sed the files in place (thanks apple),
-# we have to reset the executable bit on our shell scripts
+# find all the scripts that lost their executable bit,
+# and set it again.
 #
-find . -type f -name *.sh | xargs chmod +x
+find . -type f | grep sh$ | xargs chmod +x
 
 # the local .gradle folder will contain aritfacts with the old name.
 # clean house.

--- a/python3/py_db_sonar/README.md
+++ b/python3/py_db_sonar/README.md
@@ -6,6 +6,17 @@ If you don't need functional tests or a database, try the `py_sonar` project ins
 
 The bare-bones project is called `py_example`.
 
+
+### Make This My Own
+If you want to rename this project, and all the references to the project name,
+you can run this filling in the name you want for "new_name":
+```bash
+  ./my_project.sh new_name
+```
+
+You should *do this first*, or on a fresh checkout of this project.
+
+
 ## Database
 ### Starting
 Start the Postgres database now, since the first time you do this, it can be slow.

--- a/python3/py_db_sonar/clean.sh
+++ b/python3/py_db_sonar/clean.sh
@@ -22,6 +22,8 @@ docker rm $(docker ps -a | grep 'py_db_sonar:latest' | awk '{print $NF}')
 
 docker rmi $(docker images | tr -s ' ' | grep 'py_db_sonar latest' | cut -d' ' -f3)
 
+docker rmi $(docker images | tr -s ' ' | grep 'py_db_sonar_scanner latest' | cut -d' ' -f3)
+
 docker image prune --force
 
 docker volume rm $(docker volume ls | tr -s ' ' | grep '^local postgres_py_db_sonar' | cut -d' ' -f2)

--- a/python3/py_db_sonar/my_project.sh
+++ b/python3/py_db_sonar/my_project.sh
@@ -28,7 +28,10 @@ for file in $(find . -type f | grep fixed$)
   mv $NEW_NAME $OLD_NAME
 done
 
-chmod +x *.sh
+# find all the scripts that lost their executable bit,
+# and set it again.
+#
+find . -type f | grep sh$ | xargs chmod +x
 
 mv py_db_sonar $MY_PROJECT
 

--- a/python3/py_example/README.md
+++ b/python3/py_example/README.md
@@ -4,6 +4,15 @@ This is a **bare bones** sample python 3 project.
 
 Keep It Simple/Stupid.
 
+### Make This My Own
+If you want to rename this project, and all the references to the project name,
+you can run this filling in the name you want for "new_name":
+```bash
+  ./my_project.sh new_name
+```
+
+You should *do this first*, or on a fresh checkout of this project.
+
 ### Build and Test
 To build it, lint it, and test it, do this:
 ```bash

--- a/python3/py_example/my_project.sh
+++ b/python3/py_example/my_project.sh
@@ -14,10 +14,10 @@ if [[ "x" == "x${MY_PROJECT}" ]]
   exit 1
 fi
 
-for file in $(grep -R 'py_sonar' . | sort | awk -F':' '{print $1}' | uniq);
+for file in $(grep -R 'py_example' . | sort | awk -F':' '{print $1}' | uniq);
  do 
   echo $file
-  cat $file | sed "s|py_sonar|${MY_PROJECT}|g" > ${file}.fixed
+  cat $file | sed "s|py_example|${MY_PROJECT}|g" > ${file}.fixed
 done
 
 for file in $(find . -type f | grep fixed$)
@@ -33,5 +33,5 @@ done
 #
 find . -type f | grep sh$ | xargs chmod +x
 
-mv py_sonar $MY_PROJECT
+mv py_example $MY_PROJECT
 

--- a/python3/py_sonar/README.md
+++ b/python3/py_sonar/README.md
@@ -4,6 +4,17 @@ This is a **bare-ish bones** sample python 3 project that comes with a sonar ser
 
 For truly bare-bones, looke at the `py_example` sibling project.
 
+
+### Make This My Own
+If you want to rename this project, and all the references to the project name,
+you can run this filling in the name you want for "new_name":
+```bash
+  ./my_project.sh new_name
+```
+
+You should *do this first*, or on a fresh checkout of this project.
+
+
 ### TLDR
 
 Do this in one window:

--- a/python3/py_sonar/clean.sh
+++ b/python3/py_sonar/clean.sh
@@ -14,5 +14,7 @@ docker rm $(docker ps -a | grep 'py_sonar:latest' | awk '{print $NF}')
 
 docker rmi $(docker images | tr -s ' ' | grep 'py_sonar latest' | cut -d' ' -f3)
 
+docker rmi $(docker images | tr -s ' ' | grep 'py_sonar_scanner latest' | cut -d' ' -f3)
+
 docker image prune --force
 


### PR DESCRIPTION
### Jira
[DAB-21](http://localhost:8080/browse/DAB-21)

### What
We hit a weird edge case where the executable bit on the shell scripts copied by `my_project.sh` weren't all getting set.

This changes one-liner in `my_project.sh` that is supposed to do that.

There is a also a one-liner added to the `clean.sh` script in the python projects that build a sonar scanner docker image, that will actually remove that image during the clean.

### Why
Scripts _actually_ working is good.

### Test
I did a full smoke test off all 6 projects, starting with running the `my_project.sh` script to re-skin each project.