### PR TITLE
DAB-30: auto-initialize database

### DIFF
--- a/java8/java_db_sonar/README.md
+++ b/java8/java_db_sonar/README.md
@@ -11,10 +11,70 @@ If you don't need a database and/or functional tests, see our sibling project `j
 If you also don't need quality analysis, the barest-bones project is `java_example`.
 
 
+## Rename and Repackage This Thing
+
+If you want to take this starter project and turn it into your own project,
+you can run the `my_project.sh` script. Other starter projects in this repo
+will also have one of these.
+
+*Do This First*
+
+If you do this after changing stuff around, you'll get burned by the script.
+
+For the `my_project.sh` in _this_ project, you pass it a new project name and
+a new package name. The current project name is `java_db_sonar` and the current
+java package is `com.kakfa.db`
+
+For example, if you wanted to call this project `rabbits` and you were working for
+the devops team at a company called `example.com`, you would invoke the script
+like this:
+
+```bash
+./my_project.sh rabbits com.example.devops
+```
+
+That will change all the names in the source files in this project,
+and move the fixed up code to the new package location.
+
+Make sure you follow the final instruction by cd-ing out of the current directory,
+and then cd-ing back into the newly renamed one.
+
+After that, you can test the result by running a `rm -rf .gradle ;  ./gradlew run`
+and seeing if it spits out `Hello database.`
+
+
+## Database
+
+You should **also** do this first.
+
+### Starting The Database
+
+Start Postgres database ahead of time, because the initial download of the
+postgres docker container can be slow.
+
+```bash
+./start-db.sh ; tail -F postgres.log.txt
+```
+
+You can `ctrl-c` out of ^^^ whenever you like and check the log later if you want.
+
+You can also run that more than once without messing with the database.
+
+You'll know the database is ready when you see something like this in the log.:
+
+```bash
+test_db_1  | 1988-07-02 21:18:42.704 UTC [1] LOG:  database system is ready to accept connections
+```
+
+
 ## Quality Analysis
 
+You should **also** do this first.
+
 ### Starting
+
 To start the sonar, do this:
+
 ```bash
 ./gradlew composeUp
 ```
@@ -25,74 +85,8 @@ Then go to:
 
 and wait until it's done "starting up".
 
-NOTE: failing to wait for the sonarqubue server to be ready will cause the `./gradlew sonar` task to fail.
+NOTE: failing to wait for the sonarqube server to be ready will cause the `./gradlew sonar` task to fail.
 
-## Database
-### Starting
-Start the Postgres database now, since the first time you do this, it can be slow.
-```bash
-./start-db.sh ; tail -F postgres.log.txt
-```
-
-You can `ctrl-c` out of ^^^ whenever you like, it's just tailing the database log.
-Also, its safe to run it more than once, since it's just starting a docker-compose, which is idempotent.
-When you see that log say something like this, then the database is ready:
-```bash
-test_db_1  | 2012-12-21 03:52:16.269 UTC [1] LOG:  database system is ready to accept connections
-
-```
-
-### Setting Up
-When the database is started for the first time, it will be empty.
-Eventually it will be set up with via one of the helper scripts calling `setup-db.sh`.
-You can do that now as a test if you want:
-```bash
-./setup-db.sh
-``` 
-If it is happy, that setup script will output this:
-```bash
-CREATE ROLE
-CREATE DATABASE
-GRANT
-```
-
-### Resetting
-If you think something went wrong with the database, you can reset it by running:
-```bash
-./reset-db.sh
-```
-
-### Testing
-We included a convenience script for rerunning the functional tests which allows
-for a really tight development loop. It will drop all the database artifacts left
-behind by the functional tests, and then rerun them. 
-```bash
-./rerun-func-tests.sh 
-```
-#### Note
-At the end of running functional tests, we leave the db running, for debugging help.
-
-### Querying
-To login in to that database, run a:
-```bash
-./psql-user.sh
-```
-You can pass these scripts flags which then will then pass on to the system `psql`.
-If you weird problems, make sure your local psql is the same version (or higher) as the one in the docker container.
-You can do that like this:
-```bash
-psql --version
-``` 
-and this:
-```bash
-./psql-sudo.sh -c 'select version()'
-``` 
-As you will note, `psql-sudo.sh` script will access the database as the super user.
-If you can't do that, the database is probably down or badly damaged. 
-
-### Version
-Right now, we've pinned the postgres to version 11 in the `docker/postgres/docker-compose.yaml`
-because brew hasn't come out with v12 yet, even though that is the default postgres container now. 
 
 ### Clean It
 
@@ -103,6 +97,7 @@ you run the other tasks.
 ```bash
 ./gradlew clean
 ```
+
 
 ### Build It, Jar it, Test It, Write Report
 
@@ -139,6 +134,7 @@ An "uber" jar is a jar that has all of the project's other dependencies
 also zipped up in the jar files. For example, a regular jar might not
 include your Google Collections guava.jar, whereas an uberJar would.
 
+
 ### Run It
 
 A run will do a build.
@@ -146,6 +142,7 @@ A run will do a build.
 ```bash
 ./gradlew clean run
 ```
+
 
 ### Pushing Latest Build To Sonar
 
@@ -160,7 +157,6 @@ Note: You can type `sonar` instead of `sonarqube` if you want.
 ./gradlew sonar
 ```
 
-
 ## Development Loop
 
 If you want to rebuild and rerun everything from scratch, do this:
@@ -170,6 +166,7 @@ rm -rf .gradle ./build ./bin ; ./gradlew clean classes jar uberJar test funcTest
 ```
 
 When working properly, this is equivalent to a `./gradlew clean build sonar run`.
+
 
 ### But I Don't Need To Type That Much!
 
@@ -221,36 +218,111 @@ You may also wish to nuke your IDE artifacts, by running something like:
 rm -rf .classpath .idea .project .settings
 ```
 
-## Rename and Repackage This Thing
 
-If you want to take this starter project and turn it into your own project,
-you can run the `my_project.sh` script. Other starter projects in this repo
-will also have one of these.
+### Database Problems
 
-*Do This First*
+If you have problems with the database, it is usually because you didn't wait long enough
+before trying to access it.
 
-If you do this after changing stuff around, you'll get burned by the script.
+If you did, make sure the database initialization script ran.
 
-For the `my_project.sh` in _this_ project, you pass it a new project name and
-a new package name. The current project name is `java_db_sonar` and the current
-java package is `com.kakfa.db`
-
-For example, if you wanted to call this project `rabbits` and you were working for
-the devops team at a company called `example.com`, you would invoke the script
-like this:
+Look for this in the log:
 
 ```bash
-./my_project.sh rabbits com.example.devops
+test_db_1  | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init.sql
+test_db_1  | CREATE ROLE
+test_db_1  | CREATE DATABASE
+test_db_1  | GRANT
 ```
 
-That will change all the names in the source files in this project,
-and move the fixed up code to the new package location.
+If that broke, make sure you haven't typo-ed the local `init.sql` file,
+or the local `docker/postgres/docker-compose.yaml` file where we mount
+that those init statements.
 
-Make sure you follow the final instruction by cd-ing out of the current directory,
-and then cd-ing back into the newly renamed one.
+If for some reason you want to run that database initialization by hand,
+there's a script for that:
 
-After that, you can test the result by running a `rm -rf .gradle ;  ./gradlew run`
-and seeing if it spits out `Hello database.`
+```bash
+./setup-db.sh
+``` 
+
+The first time that init runs, it should output this:
+
+```bash
+CREATE ROLE
+CREATE DATABASE
+GRANT
+```
+
+If it already ran, and you run it again, it should spit out:
+
+```bash
+psql:init.sql:2: ERROR:  role "java_db_sonar_user" already exists
+psql:init.sql:5: ERROR:  database "java_db_sonar" already exists
+GRANT
+```
+
+### Reset The DB
+
+If you think something went wrong with the database, you can reset it by running:
+
+```bash
+./reset-db.sh
+```
+
+This will stop the database, remove it's persistent storage, and restart it.
+
+If it still doesn't work, run a `./clean.sh` and then try resetting it again.
+
+
+### Testing With The DB
+
+The pattern used by the build scripts is to reset the database before running the functional tests.
+We also included a convenience script for rerunning the functional tests which allows
+for a really tight development loop. It will drop all the database artifacts left behind
+by the functional tests, and then rerun them _without_ restarting the database.
+
+```bash
+./rerun-func-tests.sh 
+```
+
+#### Note
+
+At the end of running functional tests, our scripts leave it running, for debugging help.
+
+
+### Query The DB
+
+To login in to the database, run a:
+
+```bash
+./psql-user.sh
+```
+
+You can pass these scripts flags which then will then pass on to the system `psql`.
+If you get weird problems, make sure your local `psql` is the same version (or higher)
+as the one in the docker container.
+
+You can do that like this:
+
+```bash
+# your version
+#
+psql --version
+
+# docker image version
+#
+./psql-sudo.sh -c 'select version()'
+``` 
+
+As you will note, `psql-sudo.sh` script will access the database as the super user.
+If you can't do that, the database is probably down or badly damaged. 
+
+
+### DB Version
+
+Right now, we've pinned the postgres to version 11 in the `docker/postgres/docker-compose.yaml`
+because brew hasn't come out with v12 yet, even though that is the default postgres container now. 
 
 
 ## Enjoy!

--- a/java8/java_db_sonar/docker/postgres/docker-compose.yaml
+++ b/java8/java_db_sonar/docker/postgres/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=java_db_sonar_sudo
     volumes:
+      - ../../init.sql:/docker-entrypoint-initdb.d/init.sql
       - java_db_sonar:/var/lib/postgresql
       - java_db_sonar_data:/var/lib/postgresql/data
     ports:

--- a/java8/java_db_sonar/reset-db.sh
+++ b/java8/java_db_sonar/reset-db.sh
@@ -20,21 +20,24 @@
 #
 
 # stop the database container
+#
 ./stop-db.sh
 
 # docker needs a couple of seconds to take down the postgres network
+#
 sleep 5s
 
 # remove the persistent storage, so the database comes up blank
+#
 docker volume rm -f postgres_java_db_sonar
 docker volume rm -f postgres_java_db_sonar_data
 
 # start it up again
+#
+# the init.sql at the docker entry point dir should take care of db setup
+#
 ./start-db.sh
 
-# give it time to start, and then run the setup script
-sleep 5s
-./setup-db.sh
-
 # give it time to finish
-sleep 2s
+#
+sleep 10s

--- a/python3/py_db_sonar/README.md
+++ b/python3/py_db_sonar/README.md
@@ -1,6 +1,7 @@
 # Python3 Example with Quality Analysis and a Database
 
-This is a **semi-mature** sample python 3 project that comes with a sonar server, and a postgres database for functional tests.
+This is a **semi-mature** sample python 3 project that comes with a sonar server,
+and a postgres database for functional tests.
 
 If you don't need functional tests or a database, try the `py_sonar` project instead.
 
@@ -8,105 +9,72 @@ The bare-bones project is called `py_example`.
 
 
 ### Make This My Own
+
 If you want to rename this project, and all the references to the project name,
 you can run this filling in the name you want for "new_name":
+
 ```bash
   ./my_project.sh new_name
 ```
 
-You should *do this first*, or on a fresh checkout of this project.
+You should **do this first**, or on a fresh checkout of this project.
 
 
 ## Database
-### Starting
-Start the Postgres database now, since the first time you do this, it can be slow.
+
+You should **also** do this first.
+
+### Starting The Database
+
+Start Postgres database ahead of time, because the initial download of the
+postgres docker container can be slow.
+
 ```bash
 ./start-db.sh ; tail -F postgres.log.txt
 ```
 
-You can `ctrl-c` out of ^^^ whenever you like, it's just tailing the database log.
-Also, its safe to run it more than once, since it's just starting a docker-compose, which is idempotent.
-When you see that log say something like this, then the database is ready:
+You can `ctrl-c` out of ^^^ whenever you like and check the log later if you want.
+
+You can also run that more than once without messing with the database.
+
+You'll know the database is ready when you see something like this in the log.:
+
 ```bash
 test_db_1  | 1995-08-89 23:51:12.704 UTC [1] LOG:  database system is ready to accept connections
 ```
 
-### Setting Up
-When the database is started for the first time, it will be empty.
-Eventually it will be set up with via one of the helper scripts calling `setup-db.sh`.
-You can do that now as a test if you want:
-```bash
-./setup-db.sh
-``` 
-If it is happy, that setup script will output this:
-```bash
-CREATE ROLE
-CREATE DATABASE
-GRANT
-```
-
-### Resetting
-If you think something went wrong with the database, you can reset it by running:
-```bash
-./reset-db.sh
-```
-If it still doesn't work, run a `./clean.sh` and then try resetting it again.
-
-### Testing
-The pattern used by the build scripts is to reset the database before running the functional tests.
-We also included a convenience script for rerunning the functional tests which allows
-for a really tight development loop. It will drop all the database artifacts left behind
-by the functional tests, and then rerun them. 
-```bash
-./rerun-func-tests.sh 
-```
-#### Note
-At the end of running functional tests, our scripts leave it running, for debugging help.
-
-### Querying
-To login in to that database, run a:
-```bash
-./psql-user.sh
-```
-You can pass these scripts flags which then will then pass on to the system `psql`.
-If you weird problems, make sure your local psql is the same version (or higher) as the one in the docker container.
-You can do that like this:
-```bash
-psql --version
-``` 
-and this:
-```bash
-./psql-sudo.sh -c 'select version()'
-``` 
-As you will note, `psql-sudo.sh` script will access the database as the super user.
-If you can't do that, the database is probably down or badly damaged. 
-
-### Version
-Right now, we've pinned the postgres to version 11 in the `docker/postgres/docker-compose.yaml`
-because brew hasn't come out with v12 yet, even though that is the default postgres container now. 
-
 ## Quality Analysis
+
 You'll also need to start a docker-compose for the SonarQube server.
-We use that to see what our code coverage looks like, and get suggestions about coding style, possible bugs, security violations, and the like.
+We use that to see what our code coverage looks like, and get suggestions about coding style,
+possible bugs, security violations, and the like.
 Starting this server for the first time can also be slow.
+
 Do this in a new window:
+
 ```bash
   ./start-sonar-server.sh ; tail -F sonar.log.txt 
 ```
 
 When it you see the log saying something like this:
+
 ```bash
   sonarqube_1  | 1988.08.08 07:52:00 INFO  app[][o.s.a.SchedulerImpl] SonarQube is up
 ```
+
 Again, it's just tailing the log, so you can `ctrl-c` out of that whenever you want 
 and the sonar server will keep running.
+
 To stop it, run:
+
 ```bash
 ./stop-sonar-server.sh
 ```
 
 ## Regular Clean, Build and Run 
+
 ### clean.sh
+
 When you run a `./clean.sh` it will:
  - stop the database,
  - delete the database storage,
@@ -118,7 +86,9 @@ When you run a `./clean.sh` it will:
  
  It will not do anything to the sonar server.
 
+
 ### build.sh
+
 When you do a `./build.sh`, it will:
  - deactivate any current virtual environment,
  - remove the local virtual environment,
@@ -133,33 +103,48 @@ When you do a `./build.sh`, it will:
  - reset the test database
  - run the functional tests.
  
- ### run.sh
- It just runs the main method.
- 
+
+### run.sh
+
+It just runs the main method.
+
+### Clean It, Build It, Run It
+
 This is what you want to start from scratch on your build:
+
 ```bash
   ./clean.sh && ./build.sh && ./run.sh
 ```
 
-## Docker
+
+## Docker Built It, Run It
+
 ### Pro Tip: Don't do a clean, or you have to build again.
-A docker build will basically do what a regular build does, but it does it inside a docker contaier.
+
+A docker build will basically do what a regular build does, but it does it inside a docker container.
 The name of the container is `py_db_sonar:latest`, and if you poke around docker, you can find the image.
-The docker run exectutes the `py_db_sonar` main method from inside the container, giving it 
+The docker run executes the `py_db_sonar` main method from inside the container, giving it 
 slightly different command line args.
+
 ```bash
   ./docker-build.sh && ./docker-run.sh 
 ```
 
+
 ## Sonar
+
 ### Pro Tip: Don't do a clean, or you have to build again.
-When you do a sonar build, it grabs the local build artifiacts, such as the pylint report
+
+When you do a sonar build, it grabs the local build artifacts, such as the pylint report
 and test coverage file, and copies it along with the code into the sonar docker container.
 That container also contains a SonarScanner, which will consume those artifacts and the code
 when you run it. It knows where to find that stuff via our `sonar-project.properties` file.
+
 ```bash
   ./sonar-build.sh && ./sonar-run.sh
 ```
+
+
 ### Where are my code police violations?
 
 When you do this for the first time, before putting _your_ code in this sample project, 
@@ -179,6 +164,7 @@ in your new quality profile, and then start turning them off where they're being
 If you do this in this empty sample project, you'll see there are a lot of code smell violations,
 but turning off 2 or 3 formatting rules will take care of all of that.
 
+
 ### Changed the Rules and Still Didn't Show Up?
 
 Don't forget to set your new quality profile to the default profile.
@@ -190,13 +176,17 @@ If you also changed your code, you should first run the build.sh script, followe
 
 The other gotcha here, is that you have to log in (admin/admin) and 
 
+
 ## The Big One
+
 If you just want to run the whole flow without typing anything, here you go:
 ```bash
 ./clean.sh && ./build.sh && ./run.sh && ./docker-build.sh && ./docker-run.sh && ./sonar-build.sh && ./sonar-run.sh
 ```
 
+
 ## Done for the Day
+
 When you've found and fixed all the problems, why not clean up before you leave?
 ```bash
 ./clean.sh
@@ -205,6 +195,113 @@ When you've found and fixed all the problems, why not clean up before you leave?
 ```
 
 If you were tailing those logs, you can close those too.
+
+
+### Database Problems
+
+If you have problems with the database, it is usually because you didn't wait long enough
+before trying to access it.
+
+If you did, make sure the database initialization script ran.
+
+Look for this in the log:
+
+```bash
+test_db_1  | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init.sql
+test_db_1  | CREATE ROLE
+test_db_1  | CREATE DATABASE
+test_db_1  | GRANT
+```
+
+If that broke, make sure you haven't typo-ed the local `init.sql` file,
+or the local `docker/postgres/docker-compose.yaml` file where we mount
+that those init statements.
+
+If for some reason you want to run that database initialization by hand,
+there's a script for that:
+
+```bash
+./setup-db.sh
+``` 
+
+The first time that init runs, it should output this:
+
+```bash
+CREATE ROLE
+CREATE DATABASE
+GRANT
+```
+
+If it already ran, and you run it again, it should spit out:
+
+```bash
+psql:init.sql:2: ERROR:  role "py_db_sonar_user" already exists
+psql:init.sql:5: ERROR:  database "py_db_sonar" already exists
+GRANT
+```
+
+### Reset The DB
+
+If you think something went wrong with the database, you can reset it by running:
+
+```bash
+./reset-db.sh
+```
+
+This will stop the database, remove it's persistent storage, and restart it.
+
+If it still doesn't work, run a `./clean.sh` and then try resetting it again.
+
+
+### Testing With The DB
+
+The pattern used by the build scripts is to reset the database before running the functional tests.
+We also included a convenience script for rerunning the functional tests which allows
+for a really tight development loop. It will drop all the database artifacts left behind
+by the functional tests, and then rerun them _without_ restarting the database.
+
+```bash
+./rerun-func-tests.sh 
+```
+
+#### Note
+
+At the end of running functional tests, our scripts leave it running, for debugging help.
+
+
+### Query The DB
+
+To login in to the database, run a:
+
+```bash
+./psql-user.sh
+```
+
+You can pass these scripts flags which then will then pass on to the system `psql`.
+If you get weird problems, make sure your local `psql` is the same version (or higher)
+as the one in the docker container.
+
+You can do that like this:
+
+```bash
+# your version
+#
+psql --version
+
+# docker image version
+#
+./psql-sudo.sh -c 'select version()'
+``` 
+
+As you will note, `psql-sudo.sh` script will access the database as the super user.
+If you can't do that, the database is probably down or badly damaged. 
+
+
+### DB Version
+
+Right now, we've pinned the postgres to version 11 in the `docker/postgres/docker-compose.yaml`
+because brew hasn't come out with v12 yet, even though that is the default postgres container now. 
+
 
 ## Scripts
 

--- a/python3/py_db_sonar/docker/postgres/docker-compose.yaml
+++ b/python3/py_db_sonar/docker/postgres/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=py_db_sonar_sudo
     volumes:
+      - ../../init.sql:/docker-entrypoint-initdb.d/init.sql
       - py_db_sonar:/var/lib/postgresql
       - py_db_sonar_data:/var/lib/postgresql/data
     ports:

--- a/python3/py_db_sonar/reset-db.sh
+++ b/python3/py_db_sonar/reset-db.sh
@@ -20,21 +20,24 @@
 #
 
 # stop the database container
+#
 ./stop-db.sh
 
 # docker needs a couple of seconds to take down the postgres network
+#
 sleep 5s
 
 # remove the persistent storage, so the database comes up blank
+#
 docker volume rm -f postgres_py_db_sonar
 docker volume rm -f postgres_py_db_sonar_data
 
 # start it up again
+#
+# the init.sql at the docker entry point dir should take care of db setup
+#
 ./start-db.sh
 
-# give it time to start, and then run the setup script
-sleep 5s
-./setup-db.sh
-
 # give it time to finish
-sleep 2s
+#
+sleep 10s


### PR DESCRIPTION
### Jira
[DAB-30](http://localhost:8080/browse/DAB-30)

### What
Instead of enforcing *in documentation* that you run the database setup script after starting the db, these changes ensure that it runs automatically.

The mechanism for doing this is by mounting out `init.sql` into the docker container init directory in the docker compose.

### Why
Because I kept forgetting to run `setup-db.sh` before running functional tests, and I wrote the fucking thing.

### Testing
Testing relied on a bunch of this:
```bash
./reset-db.sh && ./rerun-func-tests.sh 
```